### PR TITLE
Support haskell-src-exts 1.16

### DIFF
--- a/haskell-generate.cabal
+++ b/haskell-generate.cabal
@@ -1,5 +1,5 @@
 name:          haskell-generate
-version:       0.2
+version:       0.2.1
 license:       BSD3
 category:      Code Generation, Language
 cabal-version: >= 1.10


### PR DESCRIPTION
Haskell-src-exts 1.16 has introduced some API change. I've added some conditional compilation to as to not change the dependency bounds in the cabal file. This now compiles and the test still passes.
